### PR TITLE
fix twitter link

### DIFF
--- a/views/archive.haml
+++ b/views/archive.haml
@@ -34,7 +34,7 @@
 				%ol
 					- ranking_archive( @year ) do |person, index|
 						%li{class: 'show'}
-							%a{href: "http://twitter/#{person['name']}"}
+							%a{href: "http://twitter.com/#{person['name']}"}
 								%img{src: person['icon']}
 							%div
 								- person['count'].times do |i|


### PR DESCRIPTION
I noticed that links to twitter from icon of union members are incomplete.
